### PR TITLE
Add eye counseling agent set

### DIFF
--- a/src/app/agentConfigs/eyeCounseling/data.ts
+++ b/src/app/agentConfigs/eyeCounseling/data.ts
@@ -1,0 +1,35 @@
+export interface EyeArticle {
+  keywords: string[];
+  answer: string;
+}
+
+export const eyeArticles: EyeArticle[] = [
+  {
+    keywords: ["白内障", "cataract"],
+    answer: "白内障は水晶体が濁って視力が低下する病気です。治療には手術が一般的です。",
+  },
+  {
+    keywords: ["緑内障", "glaucoma"],
+    answer: "緑内障は視神経が障害される病気で、早期発見と継続的な点眼治療が重要です。",
+  },
+  {
+    keywords: ["ドライアイ", "dry eye"],
+    answer: "ドライアイは涙の量や質が低下することで目が乾く状態で、人工涙液の使用が有効です。",
+  },
+  {
+    keywords: ["ものもらい", "麦粒腫", "霰粒腫"],
+    answer: "ものもらいはまぶたの腫れで、清潔を保ち必要に応じて医師の診察を受けます。",
+  },
+];
+
+export function findEyeDiseaseInfo(question: string): string {
+  const lowerQ = question.toLowerCase();
+  for (const article of eyeArticles) {
+    for (const key of article.keywords) {
+      if (lowerQ.includes(key.toLowerCase())) {
+        return article.answer;
+      }
+    }
+  }
+  return "申し訳ありません、該当する情報が見つかりませんでした。";
+}

--- a/src/app/agentConfigs/eyeCounseling/eyeRagAgent.ts
+++ b/src/app/agentConfigs/eyeCounseling/eyeRagAgent.ts
@@ -1,0 +1,37 @@
+import { AgentConfig } from "@/app/types";
+import { findEyeDiseaseInfo } from "./data";
+
+const eyeRagAgent: AgentConfig = {
+  name: "eyeCounselor",
+  publicDescription: "目の病気に関するカウンセリングを行うエージェント",
+  instructions: `
+# 役割
+- ユーザーの目の症状や病気に関する質問に答えます。
+- 必要に応じて searchEyeDisease ツールを使い、関連情報を検索して簡潔に回答します。
+  `,
+  tools: [
+    {
+      type: "function",
+      name: "searchEyeDisease",
+      description: "眼科データベースを検索して回答を取得します。",
+      parameters: {
+        type: "object",
+        properties: {
+          question: {
+            type: "string",
+            description: "ユーザーからの質問",
+          },
+        },
+        required: ["question"],
+      },
+    },
+  ],
+  toolLogic: {
+    searchEyeDisease: async ({ question }: { question: string }) => {
+      const answer = findEyeDiseaseInfo(question);
+      return { answer };
+    },
+  },
+};
+
+export default eyeRagAgent;

--- a/src/app/agentConfigs/eyeCounseling/greetingAgent.ts
+++ b/src/app/agentConfigs/eyeCounseling/greetingAgent.ts
@@ -1,0 +1,14 @@
+import { AgentConfig } from "@/app/types";
+
+const greetingAgent: AgentConfig = {
+  name: "greetingAgent",
+  publicDescription: "最初に挨拶と案内を行うエージェント",
+  instructions: `
+# 役割
+- ユーザーに挨拶を行い、このチャットが目の病気に関する相談を受け付ける窓口であると案内します。
+- ユーザーの症状や質問を簡単に確認し、必要に応じて専門エージェントへ引き継ぎます。
+  `,
+  tools: [],
+};
+
+export default greetingAgent;

--- a/src/app/agentConfigs/eyeCounseling/index.ts
+++ b/src/app/agentConfigs/eyeCounseling/index.ts
@@ -1,0 +1,11 @@
+import greetingAgent from "./greetingAgent";
+import eyeRagAgent from "./eyeRagAgent";
+import { injectTransferTools } from "../utils";
+
+greetingAgent.downstreamAgents = [eyeRagAgent];
+
+eyeRagAgent.downstreamAgents = [];
+
+const agents = injectTransferTools([greetingAgent, eyeRagAgent]);
+
+export default agents;

--- a/src/app/agentConfigs/index.ts
+++ b/src/app/agentConfigs/index.ts
@@ -3,12 +3,14 @@ import frontDeskAuthentication from "./frontDeskAuthentication";
 import customerServiceRetail from "./customerServiceRetail";
 import simpleExample from "./simpleExample";
 import adviceNLP from "./adviceNLP";
+import eyeCounseling from "./eyeCounseling";
 
 export const allAgentSets: AllAgentConfigsType = {
   frontDeskAuthentication,
   customerServiceRetail,
   simpleExample,
   adviceNLP,
+  eyeCounseling,
 };
 
 export const defaultAgentSetKey = "adviceNLP"; // Default agent set key


### PR DESCRIPTION
## Summary
- create `eyeCounseling` agent set for a greeting agent and an eye‑disease RAG agent
- register new set in agent config index

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_688731ce943883328f6d617a35b0cb37